### PR TITLE
Heb c. 13: Fix <locus> attributes to match contents

### DIFF
--- a/collections/MS_Heb_c_13.xml
+++ b/collections/MS_Heb_c_13.xml
@@ -165,7 +165,7 @@
                   </msIdentifier>
                   <msContents>
                      <msItem xml:id="MS_Heb_c_13-part5-item1">
-                        <locus from="6a" to="6b">Ff. 6-8</locus>
+                        <locus from="6a" to="8b">Ff. 6-8</locus>
                         <title>Three oblong slips containing lists of names</title>
                         <note>beg. <quote type="beg">אלשיך מחרז אלצבאג</quote>.</note>
                         <textLang mainLang="he"/>


### PR DESCRIPTION
Hello!

I'm working on the Princeton Geniza Project, where we are using your TEI to generate IIIF manifests. We found an error in MS Heb c. 13, where a `locus` node reads "Ff. 6-8" but its `to` is set to `6b` instead of `8b`. Since we rely on the `locus` nodes to determine which images to use, we need the `from` and `to` to accurately reflect the folios contained in each shelfmark.

This PR alters the `to` attribute to read `8b` in accordance with the node's text contents.